### PR TITLE
[FEATURE] Add getters to testActions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 .idea/**
+*.iml
 coverage
 dist
 node_modules
 npm-debug.log
 .DS_Store
+*.log

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@molgenis/molgenis-vue-test-utils",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Test utilities for Vue and Vuex code",
   "main": "dist/molgenis-vue-test-utils.es.js",
   "scripts": {

--- a/src/molgenis-vue-test-utils.js
+++ b/src/molgenis-vue-test-utils.js
@@ -50,6 +50,7 @@ import { expect } from 'chai'
  * @param options.state the state used in this specific action
  * @param options.expectedMutations an array of objects describing the mutations that are expected to be committed by this action
  * @param options.expectedActions an array of objects describing the actions that are expected to be dispatched by this action
+ * @param options.getters an object of possible mocks for getter calls
  *
  * @param done used to call done() which closes the Promise from calling an asynchronous api
  */
@@ -58,6 +59,7 @@ const testAction = (action, options, done) => {
   const state = options.state ? options.state : {}
   const expectedMutations = options.expectedMutations ? options.expectedMutations : []
   const expectedActions = options.expectedActions ? options.expectedActions : []
+  const getters = options.getters ? options.getters : {}
 
   let mutationCount = 0
   let actionCount = 0
@@ -98,7 +100,7 @@ const testAction = (action, options, done) => {
     }
   }
 
-  action({commit, dispatch, state}, payload)
+  action({commit, dispatch, getters, state}, payload)
 
   if (expectedMutations.length === 0 && expectedActions.length === 0) {
     expect(mutationCount).to.equal(0)

--- a/test/molgenis-vue-test-utils.spec.js
+++ b/test/molgenis-vue-test-utils.spec.js
@@ -23,7 +23,10 @@ describe('Testing utilities', () => {
         ],
         expectedActions: [
           {type: TEST_DISPATCH, payload: 'test'}
-        ]
+        ],
+        getters: {
+          testValue: 'testGetter'
+        }
       }
 
       utils.testAction(action, options, done)
@@ -35,13 +38,15 @@ describe('Testing utilities', () => {
       const TEST_COMMIT_3 = '__TEST_COMMIT_3__'
       const TEST_COMMIT_4 = '__TEST_COMMIT_4__'
       const TEST_COMMIT_5 = '__TEST_COMMIT_5__'
+      const TEST_COMMIT_6 = '__TEST_COMMIT_6__'
 
-      const action = ({commit, dispatch, state}, payload) => {
+      const action = ({commit, dispatch, getters, state}, payload) => {
         commit(TEST_COMMIT_1, null)
         commit(TEST_COMMIT_2, state.id)
         commit(TEST_COMMIT_3, state.name)
         commit(TEST_COMMIT_4, state.label)
         commit(TEST_COMMIT_5, payload)
+        commit(TEST_COMMIT_6, getters.testValue)
       }
 
       const options = {
@@ -56,7 +61,8 @@ describe('Testing utilities', () => {
           {type: TEST_COMMIT_2, payload: 'id'},
           {type: TEST_COMMIT_3, payload: 'name'},
           {type: TEST_COMMIT_4, payload: 'label'},
-          {type: TEST_COMMIT_5, payload: 'test'}
+          {type: TEST_COMMIT_5, payload: 'test'},
+          {type: TEST_COMMIT_6, payload: 'testGetter'}
         ]
       }
 


### PR DESCRIPTION
You can now use the getters in the testActions of the test-utils.